### PR TITLE
Modified dependencies for torch[vision] to >= instead of ==

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ imageio>=2.6.1
 scipy>=1.4.1
 opencv-python>=4.2.0.32
 pillow>=6.2.1
-torch==1.4.0
-torchvision==0.5.0
+torch>=1.4.0
+torchvision>=0.5.0
 click>=7.0


### PR DESCRIPTION
As discussed at Kaggle [HPA-Cell-Segmentation dependencies too strict](https://www.kaggle.com/c/hpa-single-cell-image-classification/discussion/220286), pip initially failed to install this package, as I have pytorch version 1.5.0, plus some dependency on that version (I no longer have the logs from the install-sorry). I fixed the problem by modifying requirements.txt to use >= instead of == for pytorch & torchvision, and tested (Python 3.8.5, Windows 10 64 bit) with the code from [here](https://www.kaggle.com/lnhtrang/hpa-public-data-download-and-hpacellseg). Segmentation now runs beautifully.