### PR TITLE
Update model weights url

### DIFF
--- a/hpacellseg/constants.py
+++ b/hpacellseg/constants.py
@@ -1,13 +1,13 @@
 """Shared constants for the HPA Cell Segmentation package."""
 
 NUCLEI_MODEL_URL = (
-    "https://kth.box.com/shared/static/l8z58wxkww9nn9syx9z90sclaga01mad.pth"
+    "https://zenodo.org/record/4665863/files/dpn_unet_nuclei_v1.pth"
 )
 
 MULTI_CHANNEL_CELL_MODEL_URL = (
-    "https://kth.box.com/shared/static/hl2vuyi1lugywk6fr0drdz48w90gniyv.pth"
+    "https://zenodo.org/record/4665863/files/dpn_unet_cell_3ch_v1.pth"
 )
 
 TWO_CHANNEL_CELL_MODEL_URL = (
-    "https://kth.box.com/shared/static/he8kbtpqdzm9xiznaospm15w4oqxp40f.pth"
+    "https://zenodo.org/record/4665863/files/dpn_unet_cell_v2.pth"
 )


### PR DESCRIPTION
I just uploaded the weights to Zenodo, and this PR fixes the URLs: https://zenodo.org/record/4665863
