### PR TITLE
Edited checking er_imgs variable exception message for multi channel …

### DIFF
--- a/hpacellseg/cellsegmentator.py
+++ b/hpacellseg/cellsegmentator.py
@@ -127,8 +127,10 @@ class CellSegmentator(object):
         """
         microtubule_imgs, er_imgs, nuclei_imgs = images
         if self.multi_channel_model:
-            if not isinstance(er_imgs, list):
-                raise ValueError("Please speicify the image path(s) for er channels!")
+            if er_imgs is None:
+                raise ValueError("Please specify the image path(s) for er channels!")
+            
+            assert isinstance(er_imgs, list)
         else:
             if not er_imgs is None:
                 raise ValueError(


### PR DESCRIPTION
I've been using segmentator for single image cell segmentation and received a ValueError:

```
ValueError : Please speicify the image path(s) for er channels!
```

This was raised by this line in the `cellsegmentator.py` file

```
if self.multi_channel_model:
            if not isinstance(er_imgs, list):
                raise ValueError("Please speicify the image path(s) for er channels!")
```

This condition does not check if er_imgs exists, which is what the error message implies. I've changed it to the following

```
if self.multi_channel_model:
            if er_imgs is None:
                raise ValueError("Please speicify the image path(s) for er channels!")

            assert isinstance(er_imgs, list)
```